### PR TITLE
add mapping for installer types

### DIFF
--- a/components/SingleApp.js
+++ b/components/SingleApp.js
@@ -150,15 +150,13 @@ let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = 
   }
 
   const handleInstallerType = (installerType) => {
-    const lowercaseType = installerType.toLowerCase();
-
-    switch (lowercaseType) {
+    switch (installerType) {
       case "appx":
       case "exe":
       case "msi":
       case "msix":
       case "zip":
-        return `.${lowercaseType}`
+        return `.${installerType}`
 
       case "nullsoft":
       case "inno":
@@ -286,7 +284,7 @@ let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = 
               <FiDownload />
               Download{" "}
               {app.versions[0].installerType
-                ? `(.${handleInstallerType(app.versions[0].installerType)})`
+                ? `(.${handleInstallerType(app.versions[0].installerType.toLowerCase()})`
                 : ""}
             </a>
           </li>

--- a/components/SingleApp.js
+++ b/components/SingleApp.js
@@ -149,6 +149,27 @@ let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = 
     window.open(link)
   }
 
+  const handleInstallerType = (installerType) => {
+    const lowercaseType = installerType.toLowerCase();
+
+    switch (lowercaseType) {
+      case "appx":
+      case "exe":
+      case "msi":
+      case "msix":
+      case "zip":
+        return `.${lowercaseType}`
+
+      case "nullsoft":
+      case "inno":
+      case "portable":
+        return ".exe"
+
+      case "wix":
+        return ".msi"
+    }
+  }
+
   return (
     <li
       key={app._id}
@@ -265,7 +286,7 @@ let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = 
               <FiDownload />
               Download{" "}
               {app.versions[0].installerType
-                ? `(.${app.versions[0].installerType.toLowerCase()})`
+                ? `(.${handleInstallerType(app.versions[0].installerType)})`
                 : ""}
             </a>
           </li>


### PR DESCRIPTION
I found it mildly confusing, that the single app view lists some installer types as if they were file extensions.

<img width="363" alt="image" src="https://github.com/user-attachments/assets/dd305dd8-882b-4c3c-befc-b5d1ca6e1b57">

_Screenshot: application uses InnoSetup to create setup, file extension should be `.exe`_

I see potential to take this even further, if you prefer. You might want to go with this version but also list the specific installer type, e.g.

- Download .exe (InnoSetup)
- Download .exe (NSIS)
- Download .exe (portable)

What do you think?

PS: it's great to have an up-to-date alternative to https://winget.run/ :heart:
