### PR TITLE
Attempted to remove double spacing in the install commands

### DIFF
--- a/components/SingleApp.js
+++ b/components/SingleApp.js
@@ -410,7 +410,7 @@ const Tags = ({ tags }) => {
 const Copy = ({ id, version, latestVersion }) => {
   const [showingCheck, setShowingCheck] = useState(false);
 
-  let str = `winget install --id=${id} ${version == latestVersion ? "" : `-v "${version}"`} -e`;
+  let str = `winget install --id=${id} ${version == latestVersion ? "" : `-v "${version}"`}-e`;
   
   return (
     <div


### PR DESCRIPTION
For reasons I can't decisively figure out, there's a double spacing before `-e` in the commands that are copied on the packages' Winstall pages, so that for instance copying from https://winstall.app/apps/Rakk.TalanAir results in `winget install --id=Rakk.TalanAir  -e` when having been pasted into PowerShell 7.5.2.

So I presumed that this could be a way to fix it.