### PR TITLE
Adjust format of winget install command

### DIFF
--- a/components/SingleApp.js
+++ b/components/SingleApp.js
@@ -410,7 +410,7 @@ const Tags = ({ tags }) => {
 const Copy = ({ id, version, latestVersion }) => {
   const [showingCheck, setShowingCheck] = useState(false);
 
-  let str = `winget install --id=${id} ${version == latestVersion ? "" : `-v "${version}"`} -e`;
+  let str = `winget install -e --id ${id}${version == latestVersion ? "" : ` -v "${version}"`}`;
 
   return (
     <div


### PR DESCRIPTION
For me, current format causes a couple of usability issues at once:

- Inconsistent argument-value separator: equal sign or a whitespace?
  Difficult to select and copy just the package name if your editor
  considers `=` to be part of a word, so it selects `--id=` as well.
- Double whitespace for latest version. Cosmetic issue, slightly
  annoying.
- Package name is in the middle, not a the end. This is what's really
  inconvenient. Let me explain. The package name is pretty much the
  only variable piece of the command here. When installing multiple
  packages you may want to reuse previous command from shell history:
  Up arrow key, jump to End of the line, edit the name. Or in my case I
  keep track of all installed packages in my own file Packages.ps1,
  which looks like this:

```powershell
winget install -e --id Mozilla.Firefox
winget install -e --id Mozilla.Firefox.DeveloperEdition
winget install -e --id KeePassXCTeam.KeePassXC
```

now imagine this file with `-e` at the end:

```powershell
winget install --id Mozilla.Firefox -e
winget install --id Mozilla.Firefox.DeveloperEdition -e
winget install --id KeePassXCTeam.KeePassXC -e
```

the latter looks way more cluttered, harder to navigate.

Closes #189