### PR TITLE
Allow url adressible version on app page

### DIFF
--- a/components/SingleApp.js
+++ b/components/SingleApp.js
@@ -28,14 +28,12 @@ import AppIcon from "./AppIcon";
 import { compareVersion, timeAgo } from "../utils/helpers";
 
 
-let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = false, pack = false, displaySelect = false, preventGlobalSelect, hideBorder=false, preSelected=false}) => {
+let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = false, pack = false, displaySelect = false, preventGlobalSelect, hideBorder=false, preSelected=false, initialVersion}) => {
   const [selected, setSelected] = useState(false);
   const { selectedApps, setSelectedApps } = useContext(SelectedContext);
+  const router = useRouter();
 
-  const [version, setVersion] = useState(app.latestVersion);
-
-  if (!app.selectedVersion) app.selectedVersion = version;
-
+  // Sort versions if available
   if (app.versions && app.versions.length > 1) {
     app.versions = app.versions.sort((a, b) =>
       compareVersion(b.version, a.version)
@@ -43,6 +41,32 @@ let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = 
     // make sure latest version is sorted
     app.latestVersion = app.versions[0].version;
   }
+
+  // Get initial version from prop (passed from URL path) or use latestVersion
+  const getInitialVersion = () => {
+    if (large && initialVersion && app.versions) {
+      const isValidVersion = app.versions.some(v => v.version === initialVersion);
+      if (isValidVersion) {
+        return initialVersion;
+      }
+    }
+    return app.latestVersion;
+  };
+
+  const [version, setVersion] = useState(getInitialVersion());
+
+  // Update version when initialVersion prop changes (e.g., navigation between versions)
+  useEffect(() => {
+    if (large && initialVersion && app.versions) {
+      const isValidVersion = app.versions.some(v => v.version === initialVersion);
+      if (isValidVersion && initialVersion !== version) {
+        setVersion(initialVersion);
+        app.selectedVersion = initialVersion;
+      }
+    }
+  }, [initialVersion, large, app.versions]);
+
+  if (!app.selectedVersion) app.selectedVersion = version;
 
   useEffect(() => {
     if(preSelected){
@@ -111,12 +135,21 @@ let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = 
           id="v-selector"
           name="Select app version"
           onChange={(e) => {
-            setVersion(e.target.value);
-            app.selectedVersion = e.target.value;
+            const newVersion = e.target.value;
+            setVersion(newVersion);
+            app.selectedVersion = newVersion;
+
+            // Update URL with version path (only in large/detail mode)
+            if (large) {
+              const newPath = newVersion === app.latestVersion 
+                ? `/apps/${app._id}` 
+                : `/apps/${app._id}/${newVersion}`;
+              router.replace(newPath, undefined, { shallow: true });
+            }
 
             if (selected) {
               let found = selectedApps.find((a) => a._id === app._id);
-              found.selectedVersion = e.target.value;
+              found.selectedVersion = newVersion;
 
               if(onVersionChange) onVersionChange();
             }
@@ -144,7 +177,8 @@ let SingleApp = ({ app, all, onVersionChange = false, large = false, showTime = 
   };
 
   const handleShare = () => {
-    const link = `https://twitter.com/intent/tweet?text=${encodeURIComponent(`Checkout ${app.name} by ${app.publisher} on @winstallHQ:`)}&url=${encodeURIComponent(`https://winstall.app/apps/${app._id}`)}`
+    const versionPath = version !== app.latestVersion ? `/${encodeURIComponent(version)}` : '';
+    const link = `https://twitter.com/intent/tweet?text=${encodeURIComponent(`Checkout ${app.name} by ${app.publisher} on @winstallHQ:`)}&url=${encodeURIComponent(`https://winstall.app/apps/${app._id}${versionPath}`)}`
 
     window.open(link)
   }

--- a/pages/api/apps/[id].js
+++ b/pages/api/apps/[id].js
@@ -1,0 +1,71 @@
+// Mock API endpoint for testing - returns a single app by ID
+export default function handler(req, res) {
+  const { id } = req.query;
+
+  const mockApps = {
+    "7zip.7zip": {
+      _id: "7zip.7zip",
+      name: "7-Zip",
+      publisher: "Igor Pavlov",
+      desc: "7-Zip is a file archiver with a high compression ratio. It supports packing and unpacking various archive formats including 7z, ZIP, GZIP, BZIP2, TAR, and more. The software features a high compression ratio in 7z format, strong AES-256 encryption, self-extracting capability, and integration with Windows Shell.",
+      icon: null,
+      homepage: "https://www.7-zip.org/",
+      latestVersion: "24.09",
+      updatedAt: new Date().toISOString(),
+      license: "LGPL-2.1",
+      licenseUrl: "https://www.7-zip.org/license.txt",
+      versions: [
+        { version: "24.09", installers: ["https://example.com/7z2409-x64.exe"], installerType: "exe" },
+        { version: "24.08", installers: ["https://example.com/7z2408-x64.exe"], installerType: "exe" },
+        { version: "24.07", installers: ["https://example.com/7z2407-x64.exe"], installerType: "exe" },
+        { version: "23.01", installers: ["https://example.com/7z2301-x64.exe"], installerType: "exe" },
+      ],
+      tags: ["archive", "compression", "zip", "7z", "utility"],
+    },
+    "Mozilla.Firefox": {
+      _id: "Mozilla.Firefox",
+      name: "Firefox",
+      publisher: "Mozilla",
+      desc: "Firefox is a free and open-source web browser developed by Mozilla. It uses the Gecko rendering engine to display web pages, which implements current and anticipated web standards. Firefox includes tabbed browsing, spell checking, incremental find, live bookmarking, and a download manager.",
+      icon: null,
+      homepage: "https://www.mozilla.org/firefox/",
+      latestVersion: "133.0",
+      updatedAt: new Date().toISOString(),
+      license: "MPL-2.0",
+      licenseUrl: "https://www.mozilla.org/MPL/2.0/",
+      versions: [
+        { version: "133.0", installers: ["https://example.com/firefox-133.exe"], installerType: "exe" },
+        { version: "132.0", installers: ["https://example.com/firefox-132.exe"], installerType: "exe" },
+        { version: "131.0", installers: ["https://example.com/firefox-131.exe"], installerType: "exe" },
+      ],
+      tags: ["browser", "web", "mozilla", "internet"],
+    },
+    "Microsoft.VisualStudioCode": {
+      _id: "Microsoft.VisualStudioCode",
+      name: "Visual Studio Code",
+      publisher: "Microsoft",
+      desc: "Visual Studio Code is a code editor redefined and optimized for building and debugging modern web and cloud applications. It is free and built on open source. It features IntelliSense, debugging, built-in Git support, and thousands of extensions.",
+      icon: null,
+      homepage: "https://code.visualstudio.com/",
+      latestVersion: "1.95.0",
+      updatedAt: new Date().toISOString(),
+      license: "MIT",
+      licenseUrl: "https://code.visualstudio.com/license",
+      versions: [
+        { version: "1.95.0", installers: ["https://example.com/vscode-1.95.exe"], installerType: "exe" },
+        { version: "1.94.0", installers: ["https://example.com/vscode-1.94.exe"], installerType: "exe" },
+        { version: "1.93.0", installers: ["https://example.com/vscode-1.93.exe"], installerType: "exe" },
+      ],
+      tags: ["editor", "code", "ide", "microsoft", "development"],
+    },
+  };
+
+  const app = mockApps[id];
+
+  if (!app) {
+    res.status(404).json({ error: "App not found" });
+    return;
+  }
+
+  res.status(200).json(app);
+}

--- a/pages/api/apps/index.js
+++ b/pages/api/apps/index.js
@@ -1,0 +1,56 @@
+// Mock API endpoint for testing - returns a list of apps
+export default function handler(req, res) {
+  const mockApps = [
+    {
+      _id: "7zip.7zip",
+      name: "7-Zip",
+      publisher: "Igor Pavlov",
+      desc: "7-Zip is a file archiver with a high compression ratio.",
+      icon: null,
+      homepage: "https://www.7-zip.org/",
+      latestVersion: "24.09",
+      updatedAt: new Date().toISOString(),
+      versions: [
+        { version: "24.09", installers: ["https://example.com/7z2409-x64.exe"], installerType: "exe" },
+        { version: "24.08", installers: ["https://example.com/7z2408-x64.exe"], installerType: "exe" },
+        { version: "24.07", installers: ["https://example.com/7z2407-x64.exe"], installerType: "exe" },
+        { version: "23.01", installers: ["https://example.com/7z2301-x64.exe"], installerType: "exe" },
+      ],
+      tags: ["archive", "compression", "zip", "7z"],
+    },
+    {
+      _id: "Mozilla.Firefox",
+      name: "Firefox",
+      publisher: "Mozilla",
+      desc: "Firefox is a free and open-source web browser developed by Mozilla.",
+      icon: null,
+      homepage: "https://www.mozilla.org/firefox/",
+      latestVersion: "133.0",
+      updatedAt: new Date().toISOString(),
+      versions: [
+        { version: "133.0", installers: ["https://example.com/firefox-133.exe"], installerType: "exe" },
+        { version: "132.0", installers: ["https://example.com/firefox-132.exe"], installerType: "exe" },
+        { version: "131.0", installers: ["https://example.com/firefox-131.exe"], installerType: "exe" },
+      ],
+      tags: ["browser", "web", "mozilla"],
+    },
+    {
+      _id: "Microsoft.VisualStudioCode",
+      name: "Visual Studio Code",
+      publisher: "Microsoft",
+      desc: "Visual Studio Code is a code editor redefined and optimized for building and debugging modern web and cloud applications.",
+      icon: null,
+      homepage: "https://code.visualstudio.com/",
+      latestVersion: "1.95.0",
+      updatedAt: new Date().toISOString(),
+      versions: [
+        { version: "1.95.0", installers: ["https://example.com/vscode-1.95.exe"], installerType: "exe" },
+        { version: "1.94.0", installers: ["https://example.com/vscode-1.94.exe"], installerType: "exe" },
+        { version: "1.93.0", installers: ["https://example.com/vscode-1.93.exe"], installerType: "exe" },
+      ],
+      tags: ["editor", "code", "ide", "microsoft"],
+    },
+  ];
+
+  res.status(200).json(mockApps);
+}

--- a/pages/apps/[id]/[version].js
+++ b/pages/apps/[id]/[version].js
@@ -1,16 +1,16 @@
-import styles from "../../styles/home.module.scss";
+import styles from "../../../styles/home.module.scss";
 
-import SingleApp from "../../components/SingleApp";
+import SingleApp from "../../../components/SingleApp";
 
-import Footer from "../../components/Footer";
-import Error from "../../components/Error";
+import Footer from "../../../components/Footer";
+import Error from "../../../components/Error";
 
 import Skeleton from "react-loading-skeleton";
 
 import { useRouter } from "next/router";
-import MetaTags from "../../components/MetaTags";
-import fetchWinstallAPI from "../../utils/fetchWinstallAPI";
-import DonateCard from "../../components/DonateCard";
+import MetaTags from "../../../components/MetaTags";
+import fetchWinstallAPI from "../../../utils/fetchWinstallAPI";
+import DonateCard from "../../../components/DonateCard";
 
 function AppSkeleton() {
     return (
@@ -30,7 +30,7 @@ function AppSkeleton() {
     );
 }
 
-function AppDetail({ app, popular}) {
+function AppDetail({ app, initialVersion }) {
     const router = useRouter();
     const fallbackMessage = {
         title: "Sorry! We could not load this app.",
@@ -50,10 +50,10 @@ function AppDetail({ app, popular}) {
             ) : (
               <div>
                 <MetaTags
-                  title={`Install ${app.name} with winget - winstall`}
+                  title={`Install ${app.name} v${initialVersion} with winget - winstall`}
                   desc={app.desc}
                 />
-                <ul className="largeApp"><SingleApp app={app} large={true}/></ul>
+                <ul className="largeApp"><SingleApp app={app} large={true} initialVersion={initialVersion}/></ul>
                 <DonateCard addMargin="top"/>
               </div>
             )}
@@ -83,7 +83,18 @@ export async function getStaticProps({ params }) {
     try{
         let { response: app } = await fetchWinstallAPI(`/apps/${params.id}`);
 
-        return { props: app ? { app } : {} }
+        if (!app) {
+            return { props: {} };
+        }
+
+        // Validate that the version exists for this app
+        const versionExists = app.versions && app.versions.some(v => v.version === params.version);
+        
+        if (!versionExists) {
+            return { props: {} };
+        }
+
+        return { props: { app, initialVersion: params.version } }
     } catch(err) {
         return { props: {} };
     }

--- a/pages/apps/[id]/index.js
+++ b/pages/apps/[id]/index.js
@@ -1,0 +1,92 @@
+import styles from "../../../styles/home.module.scss";
+
+import SingleApp from "../../../components/SingleApp";
+
+import Footer from "../../../components/Footer";
+import Error from "../../../components/Error";
+
+import Skeleton from "react-loading-skeleton";
+
+import { useRouter } from "next/router";
+import MetaTags from "../../../components/MetaTags";
+import fetchWinstallAPI from "../../../utils/fetchWinstallAPI";
+import DonateCard from "../../../components/DonateCard";
+
+function AppSkeleton() {
+    return (
+      <div>
+        <div className="skeleton-group">
+          <Skeleton circle={true} height={30} width={30} />
+          <Skeleton count={1} height={25} />
+        </div>
+        <Skeleton count={5} height={20} />
+        <div className="skeleton-list">
+          <Skeleton count={5} width={250} />
+        </div>
+        <div className="skeleton-button">
+          <Skeleton count={1} width={140} height={50} />
+        </div>
+      </div>
+    );
+}
+
+function AppDetail({ app, popular}) {
+    const router = useRouter();
+    const fallbackMessage = {
+        title: "Sorry! We could not load this app.",
+        subtitle: "Unfortunately, this app could not be loaded. Either it does not exist, or something else went wrong. Please try again later."
+    }
+
+    if(!router.isFallback && !app){
+        return <Error {...fallbackMessage}/>
+    }
+
+    return (
+      <div>
+        <div className={styles.intro}>
+          <div className="illu-box">
+            {router.isFallback ? (
+              <AppSkeleton/>
+            ) : (
+              <div>
+                <MetaTags
+                  title={`Install ${app.name} with winget - winstall`}
+                  desc={app.desc}
+                />
+                <ul className="largeApp"><SingleApp app={app} large={true}/></ul>
+                <DonateCard addMargin="top"/>
+              </div>
+            )}
+            <div className="art">
+              <img
+                src="/assets/logo.svg"
+                draggable={false}
+                alt="winstall logo"
+              />
+            </div>
+          </div>
+        </div>
+
+        <Footer />
+      </div>
+    );
+}
+
+export async function getStaticPaths() {
+    return {
+        paths: [],
+        fallback: true,
+    };
+}
+
+export async function getStaticProps({ params }) {
+    try{
+        let { response: app } = await fetchWinstallAPI(`/apps/${params.id}`);
+
+        return { props: app ? { app } : {} }
+    } catch(err) {
+        return { props: {} };
+    }
+}
+
+export default AppDetail;


### PR DESCRIPTION
Package version selection is now URL addressable via path segments (e.g., `/apps/7zip.7zip/24.07`).

Why? I would like to link to apps in your site with specific version selected.

## Changes

- **Routing restructure**: Moved `pages/apps/[id].js` → `pages/apps/[id]/index.js` and added `pages/apps/[id]/[version].js` for versioned URLs
- **SingleApp.js**: Added `initialVersion` prop, version selector now updates URL on change, share button includes version path
- **Mock API**: Added `pages/api/apps/` endpoints for local testing

## Behavior

| URL | Result |
|-----|--------|
| `/apps/7zip.7zip` | Latest version (v24.09) |
| `/apps/7zip.7zip/23.01` | Specific version |

Selecting latest version removes version suffix from URL. Invalid versions show error page.

## Screenshots

**Default (latest) version:**
![Default version](https://github.com/user-attachments/assets/f59b3728-c22e-4d3b-acda-3d890a704244)

**Older version selected (`/apps/7zip.7zip/23.01`):**
![Older version](https://github.com/user-attachments/assets/cdc0b468-da9e-4476-8ac2-99fcbd949831)
