### PR TITLE
Format app count

### DIFF
--- a/pages/apps.js
+++ b/pages/apps.js
@@ -137,7 +137,7 @@ function Store({ data, error }) {
   const Title = () => {
     return (
       <>
-        {!searchInput && <h1>All apps {`(${apps.length})`}</h1>}
+        {!searchInput && <h1>All apps {`(${apps.length.toLocaleString()})`}</h1>}
         {searchInput && (
           <>
             {searchInput.startsWith("tags: ") && (


### PR DESCRIPTION
This will ensure that the count on the app page uses a separator