### PR TITLE
Security: Server-Side Request Forgery (SSRF) in Twitter API endpoint

### DIFF
--- a/pages/api/twitter.js
+++ b/pages/api/twitter.js
@@ -1,4 +1,29 @@
+const ALLOWED_TWITTER_HOSTS = ['api.twitter.com', 'api.x.com'];
+const ALLOWED_TWITTER_PATHS = [
+    '/2/tweets',
+    '/2/users',
+    '/2/search/recent',
+    '/2/tweets/search/recent',
+    '/1.1/statuses',
+    '/1.1/users'
+];
+
+const isAllowedEndpoint = (url) => {
+    try {
+        const parsed = new URL(url);
+        const isAllowedHost = ALLOWED_TWITTER_HOSTS.includes(parsed.hostname);
+        const isAllowedPath = ALLOWED_TWITTER_PATHS.some(path => parsed.pathname.startsWith(path));
+        return isAllowedHost && isAllowedPath;
+    } catch {
+        return false;
+    }
+};
+
 export const callTwitterAPI = async (endpoint, method="GET") => {
+    if (!isAllowedEndpoint(endpoint)) {
+        return { response: null, error: 'Invalid or disallowed endpoint' };
+    }
+
     let response, error;
 
     try {


### PR DESCRIPTION
## Summary

Security: Server-Side Request Forgery (SSRF) in Twitter API endpoint

## Problem

**Severity**: `Critical` | **File**: `pages/api/twitter.js:L1`

In pages/api/twitter.js, the endpoint header from the request is used directly to make API calls without validation. An attacker can manipulate the 'endpoint' header to make the server request arbitrary URLs, potentially accessing internal services or exfiltrating data.

## Solution

Add whitelist validation for allowed Twitter API endpoints. Only allow requests to known Twitter API domains (e.g., api.twitter.com). Remove the ability for clients to specify arbitrary endpoints.

## Changes

- `pages/api/twitter.js` (modified)